### PR TITLE
fix short-circuit oneToOne prop check

### DIFF
--- a/src/HighchartsReact.js
+++ b/src/HighchartsReact.js
@@ -17,11 +17,11 @@ var HighchartsReact = createReactClass({
   },
 
   componentDidUpdate: function () {
-    this.chart.update(Object.assign({}, this.props.options), true, this.props.oneToOne || true)
+    this.chart.update(Object.assign({}, this.props.options), true, !(this.props.oneToOne === false))
   },
 
   componentWillReceiveProps: function () {
-    this.chart.update(Object.assign({}, this.props.options), true, this.props.oneToOne || true)
+    this.chart.update(Object.assign({}, this.props.options), true, !(this.props.oneToOne === false))
   },
 
   componentWillUnmount: function () {


### PR DESCRIPTION
Hi Highcharts-React-Official,

There is an issue in the `oneToOne` prop type check. Under the current implementation, it will always default to `true`. Because of [an outstanding issue with highcharts](https://github.com/highcharts/highcharts/issues/8196), `highcharts-react-official` won't work with `oneToOne` being `true` for the `stockChart` presently… at least for me. This PR should allow people to use `stockChart` if they add `oneToOne={false}`.