### PR TITLE
Don't mix import and module.exports

### DIFF
--- a/src/HighchartsReact.js
+++ b/src/HighchartsReact.js
@@ -40,4 +40,4 @@ class HighchartsReact extends React.PureComponent {
   }
 }
 
-module.exports = HighchartsReact;
+export default HighchartsReact;


### PR DESCRIPTION
Started getting an error after last update. According to [this issue](https://github.com/webpack/webpack/issues/4039), you shouldn't mix `import` and `module.exports` in the same file