### PR TITLE
invalid license xml fix, angle brackets removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.2",
   "main": "./dist/highcharts-react.min.js",
   "types": "./dist/highcharts-react.min.d.ts",
-  "license": "SEE LICENSE IN <LICENSE>",
+  "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/highcharts/highcharts-react"


### PR DESCRIPTION
Angle brackets license are causing SBOM xml to be invalid (opening <LICENSE> tag only)
Removing them fixes the problems
Example: using highghcharts-react and https://cyclonedx.org/