### PR TITLE
Update minimum required version for React

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tested and required versions:
 
 This wrapper also requires highcharts and react packages with following versions installed in your project:
 
-* `react` 16.4+
+* `react` 16.6+
 * `highcharts` 5.0.0+
 
 ### Installing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tested and required versions:
 
 This wrapper also requires highcharts and react packages with following versions installed in your project:
 
-* `react` 16.6+
+* `react` 16.8+
 * `highcharts` 5.0.0+
 
 ### Installing


### PR DESCRIPTION
This change will update the read me to state that the required version for React is 16.8+ instead of 16.4. Some of the features used in this library, most notable React.memo, and any React Hooks used in the library.

Having the required React version be v16.4+ made things very confusing for me when the library didn't seem to work. Hopefully this change will keep anyone else from having these issues.

References:
* https://reactjs.org/blog/2018/10/23/react-v-16-6.html
* https://reactjs.org/blog/2019/02/06/react-v16.8.0.html

