### PR TITLE
Update readme to use ES6 bound class methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,12 +367,7 @@ render() {
 or store it by the callback function:
 
 ```jsx
-constructor(props) {
-  super(props);
-  this.afterChartCreated = this.afterChartCreated.bind(this);
-}
-
-afterChartCreated(chart) {
+afterChartCreated = (chart) => {
   this.internalChart = chart;
 }
 


### PR DESCRIPTION
In ES6, you can use the fat arrow (=>) to bind class methods to the this context.  Using this syntax is cleaner than calling bind from the constructor.