### PR TITLE
Fix chart reference for typescript users

### DIFF
--- a/dist/highcharts-react.d.ts
+++ b/dist/highcharts-react.d.ts
@@ -14,7 +14,7 @@ declare const HighchartsReact: React.ForwardRefExoticComponent<
       /**
        * Chart reference
        */
-      chart: Highcharts.Chart;
+      chart: Highcharts.ChartObject;
 
       /**
        * React reference

--- a/dist/highcharts-react.min.d.ts
+++ b/dist/highcharts-react.min.d.ts
@@ -14,7 +14,7 @@ declare const HighchartsReact: React.ForwardRefExoticComponent<
       /**
        * Chart reference
        */
-      chart: Highcharts.Chart;
+      chart: Highcharts.ChartObject;
 
       /**
        * React reference

--- a/src/HighchartsReact.d.ts
+++ b/src/HighchartsReact.d.ts
@@ -14,7 +14,7 @@ declare const HighchartsReact: React.ForwardRefExoticComponent<
       /**
        * Chart reference
        */
-      chart: Highcharts.Chart;
+      chart: Highcharts.ChartObject;
 
       /**
        * React reference


### PR DESCRIPTION
See issue https://github.com/highcharts/highcharts-react/issues/230 for context

thanks to @ppotaczek I was able to use ref in a typescript project, but then I realized there was a small typing issue,that I'm trying to fix here.