### PR TITLE
This project is MIT licensed

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "main": "./dist/highcharts-react.min.js",
   "types": "./dist/highcharts-react.min.d.ts",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/highcharts/highcharts-react"


### PR DESCRIPTION
That a related project has a different license does not change this. Specifying the license correctly makes user's lives much easier with license compliance enforcement software.