### PR TITLE
Fix build-demo script in package.json and removing unnecessary codes in HighchartsReact.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "build-demo": "browserify ./demo/demo.jsx -o ./demo/bundle.js -t [ babelify --presets [ env react ] ]",
+    "build-demo": "browserify ./demo/demo.jsx -o ./demo/bundle.js -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ]",
     "build": "webpack --config webpack.config.js",
     "release": "standard-version"
   },

--- a/src/HighchartsReact.js
+++ b/src/HighchartsReact.js
@@ -43,7 +43,7 @@ const HighchartsReact = forwardRef(
           chartRef.current = H[constructorType](
             containerRef.current,
             props.options,
-            props.callback ? props.callback : undefined
+            props.callback
           );
         }
       }
@@ -52,7 +52,7 @@ const HighchartsReact = forwardRef(
         createChart();
       } else {
         if (props.allowChartUpdate !== false) {
-          if (!props.immutable && chartRef.current) {
+          if (!props.immutable) {
             chartRef.current.update(
               props.options,
               ...(props.updateArgs || [true, true])


### PR DESCRIPTION
**Problem:**
 i)While Running build-demo script in local, it will throw below errors
 ii)Removing unnecessary codes in HighchartsReact.js
 
![preset-env](https://user-images.githubusercontent.com/22814641/160453507-943f10e9-7074-4e40-a67c-81a24da0340c.jpg)
![preset-react error](https://user-images.githubusercontent.com/22814641/160453526-f76920fd-3077-4c4b-9a3c-1ef384fdd76a.jpg)

**Solution:**
  i)To avoid  above errors, need to change the build-demo script as ``[ babelify --presets [ @babel/preset-env @babel/preset-react ] ]`` instead of ``[ babelify --presets [ env react ] ]``
 ii) a) Restructured ``props.callback ? props.callback : undefined`` as ``props.callback``. if props doesn't have callback, default value will be ``undefined``
     b) ``chartRef.current`` removed in else statement. since if statement checked as !chartRef.current, so always ``chartRef.current`` will have value in else statement