### PR TITLE
Update SSR render check

### DIFF
--- a/src/HighchartsReact.js
+++ b/src/HighchartsReact.js
@@ -13,7 +13,9 @@ import React, {
 // `Highcharts` ref is available in the layout phase. This makes it available
 // in a parent component's `componentDidMount`.
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+  typeof window !== 'undefined' && typeof window.document !== 'undefined'
+    ? useLayoutEffect
+    : useEffect;
 
 export const HighchartsReact = memo(forwardRef(
   function HighchartsReact(props, ref) {


### PR DESCRIPTION
Suggest to enhance SSR render check. Because most React apps override global `window` for server render.