### PR TITLE
chore: remove console.log in hooks

### DIFF
--- a/Gantt.js
+++ b/Gantt.js
@@ -201,7 +201,6 @@ export function GanttChart(props) {
             const children = toArr(props.children).filter((c) => { var _a; return ((_a = c === null || c === void 0 ? void 0 : c.type) === null || _a === void 0 ? void 0 : _a.type) === "Series"; });
             children.forEach((c, i) => {
                 var _a;
-                console.log("Adding series to chart");
                 if (c.props) {
                     const _b = c.props, { children, type, options } = _b, otherProps = __rest(_b, ["children", "type", "options"]);
                     if (options) {
@@ -214,14 +213,11 @@ export function GanttChart(props) {
     };
     // Update the chart on render
     useEffect(() => {
-        console.log(JSON.stringify(chartConfig, undefined, "  "));
         if (!chartRef.current) {
             const HCConstructor = props.chartConstructor || "ganttChart";
-            console.log("Creating chart using", HCConstructor, "constructor");
             chartRef.current = getHighcharts()[HCConstructor](containerRef.current, chartConfig);
         }
         else {
-            console.log("Updating chart", JSON.parse(JSON.stringify(chartConfig)));
             appendProps(chartConfig);
             appendSeries(); // chartConfig
             chartRef.current.update(Object.assign(Object.assign({}, chartConfig), getChildProps(props.children, renderToStaticMarkup)), true);

--- a/Highcharts.js
+++ b/Highcharts.js
@@ -201,7 +201,6 @@ export function Chart(props) {
             const children = toArr(props.children).filter((c) => { var _a; return ((_a = c === null || c === void 0 ? void 0 : c.type) === null || _a === void 0 ? void 0 : _a.type) === "Series"; });
             children.forEach((c, i) => {
                 var _a;
-                console.log("Adding series to chart");
                 if (c.props) {
                     const _b = c.props, { children, type, options } = _b, otherProps = __rest(_b, ["children", "type", "options"]);
                     if (options) {
@@ -214,14 +213,11 @@ export function Chart(props) {
     };
     // Update the chart on render
     useEffect(() => {
-        console.log(JSON.stringify(chartConfig, undefined, "  "));
         if (!chartRef.current) {
             const HCConstructor = props.chartConstructor || "chart";
-            console.log("Creating chart using", HCConstructor, "constructor");
             chartRef.current = getHighcharts()[HCConstructor](containerRef.current, chartConfig);
         }
         else {
-            console.log("Updating chart", JSON.parse(JSON.stringify(chartConfig)));
             appendProps(chartConfig);
             appendSeries(); // chartConfig
             chartRef.current.update(Object.assign(Object.assign({}, chartConfig), getChildProps(props.children, renderToStaticMarkup)), true);

--- a/Maps.js
+++ b/Maps.js
@@ -201,7 +201,6 @@ export function MapsChart(props) {
             const children = toArr(props.children).filter((c) => { var _a; return ((_a = c === null || c === void 0 ? void 0 : c.type) === null || _a === void 0 ? void 0 : _a.type) === "Series"; });
             children.forEach((c, i) => {
                 var _a;
-                console.log("Adding series to chart");
                 if (c.props) {
                     const _b = c.props, { children, type, options } = _b, otherProps = __rest(_b, ["children", "type", "options"]);
                     if (options) {
@@ -214,14 +213,11 @@ export function MapsChart(props) {
     };
     // Update the chart on render
     useEffect(() => {
-        console.log(JSON.stringify(chartConfig, undefined, "  "));
         if (!chartRef.current) {
             const HCConstructor = props.chartConstructor || "mapChart";
-            console.log("Creating chart using", HCConstructor, "constructor");
             chartRef.current = getHighcharts()[HCConstructor](containerRef.current, chartConfig);
         }
         else {
-            console.log("Updating chart", JSON.parse(JSON.stringify(chartConfig)));
             appendProps(chartConfig);
             appendSeries(); // chartConfig
             chartRef.current.update(Object.assign(Object.assign({}, chartConfig), getChildProps(props.children, renderToStaticMarkup)), true);

--- a/Stock.js
+++ b/Stock.js
@@ -201,7 +201,6 @@ export function StockChart(props) {
             const children = toArr(props.children).filter((c) => { var _a; return ((_a = c === null || c === void 0 ? void 0 : c.type) === null || _a === void 0 ? void 0 : _a.type) === "Series"; });
             children.forEach((c, i) => {
                 var _a;
-                console.log("Adding series to chart");
                 if (c.props) {
                     const _b = c.props, { children, type, options } = _b, otherProps = __rest(_b, ["children", "type", "options"]);
                     if (options) {
@@ -214,14 +213,11 @@ export function StockChart(props) {
     };
     // Update the chart on render
     useEffect(() => {
-        console.log(JSON.stringify(chartConfig, undefined, "  "));
         if (!chartRef.current) {
             const HCConstructor = props.chartConstructor || "stockChart";
-            console.log("Creating chart using", HCConstructor, "constructor");
             chartRef.current = getHighcharts()[HCConstructor](containerRef.current, chartConfig);
         }
         else {
-            console.log("Updating chart", JSON.parse(JSON.stringify(chartConfig)));
             appendProps(chartConfig);
             appendSeries(); // chartConfig
             chartRef.current.update(Object.assign(Object.assign({}, chartConfig), getChildProps(props.children, renderToStaticMarkup)), true);


### PR DESCRIPTION
Those console.log in the hooks are logging a lot of stuff in the console. Including the data which can be quite large.
I was not sure that v4-beta was the correct branch to target, but it seems to be that the npm package is published from this branch.